### PR TITLE
Add dashboard import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ npm run seed
 npm start
 ```
 
-4. Open <http://localhost:3000> in your browser. Click **Add Chart** to create a new chart widget. Each widget pulls data from the `sampledata` collection and renders a bar chart with ECharts.
+4. Open <http://localhost:3000> in your browser. Click **Add Chart** to create a new chart widget. Use **Export** to download the dashboard layout as `dashboard.json` and **Import** to load it back. Each widget pulls data from the `sampledata` collection and renders a bar chart with ECharts.
 
 ## Files
 
 - `server.js` – Express server providing a `/data/:collection` API and serving static files.
 - `public/index.html` – Front-end using Gridstack.js for layout and ECharts for rendering.
 - `seed.js` – Seeds the `sampledata` collection with example documents.
+
+## Exporting and Importing
+
+Use the **Export** button to download the current dashboard layout as a JSON file. You can later restore the dashboard by clicking **Import** and selecting the previously saved file.

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,9 @@
 </head>
 <body>
   <button id="addChart">Add Chart</button>
+  <button id="export">Export</button>
+  <button id="import">Import</button>
+  <input type="file" id="fileInput" accept="application/json" style="display:none" />
   <div class="grid-stack"></div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/4.3.1/gridstack-h5.js"></script>
@@ -19,13 +22,25 @@
   <script>
     const grid = GridStack.init({ float: true });
 
-    document.getElementById('addChart').addEventListener('click', async () => {
-      const node = grid.addWidget(`<div class="grid-stack-item-content"><div class="chart-container"></div></div>`, {w:4, h:4});
+    document.getElementById('addChart').addEventListener('click', () => {
+      addChart({ w: 4, h: 4, collection: 'sampledata' });
+    });
+
+    document.getElementById('export').addEventListener('click', exportDashboard);
+    document.getElementById('import').addEventListener('click', () => document.getElementById('fileInput').click());
+    document.getElementById('fileInput').addEventListener('change', importDashboard);
+
+    function addChart(opts) {
+      const node = grid.addWidget(
+        `<div class="grid-stack-item-content"><div class="chart-container"></div></div>`,
+        opts
+      );
+      node.dataset.collection = opts.collection;
       const chartDom = node.querySelector('.chart-container');
       const chart = echarts.init(chartDom);
-      const data = await fetchData('sampledata');
-      chart.setOption(buildOption(data));
-    });
+      fetchData(opts.collection).then(data => chart.setOption(buildOption(data)));
+      return node;
+    }
 
     async function fetchData(collection) {
       const res = await fetch(`/data/${collection}`);
@@ -39,6 +54,34 @@
         yAxis: { type: 'value' },
         series: [{ type: 'bar', data: data.map(d => d.value) }]
       };
+    }
+
+    function exportDashboard() {
+      const layout = Array.from(document.querySelectorAll('.grid-stack-item')).map(el => ({
+        x: parseInt(el.getAttribute('gs-x')) || 0,
+        y: parseInt(el.getAttribute('gs-y')) || 0,
+        w: parseInt(el.getAttribute('gs-w')) || 1,
+        h: parseInt(el.getAttribute('gs-h')) || 1,
+        collection: el.dataset.collection || 'sampledata'
+      }));
+      const blob = new Blob([JSON.stringify(layout, null, 2)], { type: 'application/json' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'dashboard.json';
+      a.click();
+      URL.revokeObjectURL(a.href);
+    }
+
+    async function importDashboard(e) {
+      const file = e.target.files[0];
+      if (!file) return;
+      const text = await file.text();
+      const layout = JSON.parse(text);
+      grid.removeAll();
+      for (const w of layout) {
+        addChart(w);
+      }
+      e.target.value = '';
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- enable exporting and importing dashboard widgets via JSON
- document the export/import workflow

## Testing
- `npm install --no-audit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847d5d5c31c8325bcf76c0be389d18f