### PR TITLE
Add default dashboard cards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,8 +19,16 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/4.3.1/gridstack-h5.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/echarts/5.4.2/echarts.min.js"></script>
-  <script>
-    const grid = GridStack.init({ float: true });
+    <script>
+      const grid = GridStack.init({ float: true });
+
+      const defaultLayout = [
+        { x: 0, y: 0, w: 4, h: 4, collection: 'sampledata' },
+        { x: 4, y: 0, w: 4, h: 4, collection: 'sampledata' },
+        { x: 8, y: 0, w: 4, h: 4, collection: 'sampledata' }
+      ];
+
+      defaultLayout.forEach(addChart);
 
     document.getElementById('addChart').addEventListener('click', () => {
       addChart({ w: 4, h: 4, collection: 'sampledata' });


### PR DESCRIPTION
## Summary
- automatically load a few starter widgets in the dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847e45452cc8325957657f1e1d87e1b